### PR TITLE
chore: remove superfences from markdown_extensions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,17 +40,17 @@ extra_javascript:
 markdown_extensions:
   - pymdownx.arithmatex:
       generic: true
-  - pymdownx.superfences:
-      custom_fences:
-        - name: mermaid
-          class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
-        - name: math
-          class: arithmatex
-          format:
-            !!python/object/apply:pymdownx.arithmatex.arithmatex_fenced_format {
-              which: generic,
-            }
+  #  - pymdownx.superfences:
+  #     custom_fences:
+  #      - name: mermaid
+  #       class: mermaid
+  #      format: !!python/name:pymdownx.superfences.fence_code_format
+  #   - name: math
+  #    class: arithmatex
+  #   format:
+  #    !!python/object/apply:pymdownx.arithmatex.arithmatex_fenced_format {
+  #     which: generic,
+  #  }
   - footnotes
 
 extra_css:


### PR DESCRIPTION
This PR removes the superfences plugin from the markdown_extensions list in the `mkdocs.yml` file.

The superfences plugin defines custom fences, in our case it defines `mermaid` and `math`. These are not being used in the docs, but the plugin is causing errors on the  [Publish TechDocs Site](https://github.com/liatrio/openo11y.dev/actions/workflows/publish-techdocs-to-s3.yaml) workflow.

```info: Generating documentation...
unknown tag !<tag:yaml.org,[20](https://github.com/liatrio/openo11y.dev/actions/runs/10620843690/job/29441498230#step:17:21)02:python/object/apply:pymdownx.arithmatex.arithmatex_fenced_format> (53:14)```