### PR TITLE
chore: remove bracket syntax in math custom fence

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,17 +40,17 @@ extra_javascript:
 markdown_extensions:
   - pymdownx.arithmatex:
       generic: true
-  #  - pymdownx.superfences:
-  #     custom_fences:
-  #      - name: mermaid
-  #       class: mermaid
-  #      format: !!python/name:pymdownx.superfences.fence_code_format
-  #   - name: math
-  #    class: arithmatex
-  #   format:
-  #    !!python/object/apply:pymdownx.arithmatex.arithmatex_fenced_format {
-  #     which: generic,
-  #  }
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+        - name: math
+          class: arithmatex
+          format:
+            !!python/object/apply:pymdownx.arithmatex.arithmatex_fenced_format
+            which: generic
+
   - footnotes
 
 extra_css:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,17 +40,17 @@ extra_javascript:
 markdown_extensions:
   - pymdownx.arithmatex:
       generic: true
-  - pymdownx.superfences:
-      custom_fences:
-        - name: mermaid
-          class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
-        - name: math
-          class: arithmatex
-          format:
-            !!python/object/apply:pymdownx.arithmatex.arithmatex_fenced_format {
-              which: generic,
-            }
+  #  - pymdownx.superfences:
+  #     custom_fences:
+  #      - name: mermaid
+  #       class: mermaid
+  #      format: !!python/name:pymdownx.superfences.fence_code_format
+  #   - name: math
+  #    class: arithmatex
+  #   format:
+  #    !!python/object/apply:pymdownx.arithmatex.arithmatex_fenced_format {
+  #     which: generic,
+  #  }
   - footnotes
 
 extra_css:


### PR DESCRIPTION
The Publish Tech Doc workflow is unable to read the syntax of the math custom fence.

The math custom fence is designed to handle fenced code blocks that contain mathematical expressions. 

`format:
            !!python/object/apply:pymdownx.arithmatex.arithmatex_fenced_format {
              which: generic,
            }`
            
This could be because of the bracket syntax used to declare the attribute "generic"

Changed the syntax to be better

` format:
            !!python/object/apply:pymdownx.arithmatex.arithmatex_fenced_format
            which: generic`

This change removes the brackets and separates the which: generic attribute, making it more straightforward and potentially more compatible with the Publish Tech Doc workflow.