### PR TITLE
fix: remove unused custom fence

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,13 +45,6 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
-        - name: math
-          class: arithmatex
-          format:
-            !!python/object/apply:pymdownx.arithmatex.arithmatex_fenced_format {
-              which: generic,
-            }
-
   - footnotes
 
 extra_css:


### PR DESCRIPTION
This PR removes an unused custom fence configured in `mkdocs.yaml`

Why: this configuration was blocking a step in the Publish workflow, and it is not needed anymore.

https://github.com/liatrio/openo11y.dev/actions/runs/10616857888/job/29428294345
    